### PR TITLE
Add WDePOS Maven repository and update SDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,12 +29,11 @@ android {
 repositories {
     google()
     mavenCentral()
-    // Se tiver repositório Maven do WDePOS, adicione aqui
-    // maven { url "https://maven.wdepos.com/repository/maven-public/" }
+    maven { url "https://maven.wdepos.com/repository/maven-public/" }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.21"
-    // Dependência WDePOS (ajuste para o correto)
-    implementation 'com.wdepos:sdk:1.0.0'
+    // Dependência WDePOS atualizada
+    implementation 'com.wdepos:sdk:1.0.11'
 }

--- a/example/android/build.gradle.kts
+++ b/example/android/build.gradle.kts
@@ -2,6 +2,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://maven.wdepos.com/repository/maven-public/")
     }
 }
 


### PR DESCRIPTION
## Summary
- add WDePOS Maven repository to Android builds
- bump WDePOS SDK to 1.0.11
- ensure example project inherits repository config

## Testing
- `flutter test` *(fails: command not found)*
- `gradle help` *(fails: Plugin [id: 'com.android.library'] was not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c9ac367808331a261f928a4d02a3b