### PR TITLE
feat: support environment selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.5] - 2025-08-12
+### Added
+- Optional `environment` parameter for `generateNonce` to switch between test and production.
+
 ## [0.0.4] - 2025-08-12
 ### Added
 - Support for WDePOS on iOS and Android.

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ final nonce = await authorizeNet.generateNonce(
   expirationMonth: '12',
   expirationYear: '25',
   cardCode: '123',
+  environment: 'test', // or 'production'
 );
 
 print('Generated nonce: $nonce');
 
 // Send this nonce securely to your backend to complete the payment
 ```
+
+The `environment` parameter is optional and defaults to `'test'`. Use `'production'` when processing real transactions.

--- a/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
+++ b/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
@@ -32,6 +32,7 @@ public class AuthorizeNetSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHand
             val expirationMonth = call.argument<String>("expirationMonth") ?: ""
             val expirationYear = call.argument<String>("expirationYear") ?: ""
             val cardCode = call.argument<String>("cardCode") ?: ""
+            val environmentArg = call.argument<String>("environment") ?: "test"
 
             if (apiLoginId.isEmpty() || clientKey.isEmpty() || cardNumber.isEmpty() || expirationMonth.isEmpty() || expirationYear.isEmpty() || cardCode.isEmpty()) {
                 result.error("INVALID_ARGS", "Parâmetros inválidos ou faltando", null)
@@ -39,7 +40,11 @@ public class AuthorizeNetSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHand
             }
 
             // Configura o ambiente (sandbox/teste ou produção)
-            val environment = WDePOSEnvironment.TEST
+            val environment = if (environmentArg.equals("production", ignoreCase = true)) {
+                WDePOSEnvironment.PRODUCTION
+            } else {
+                WDePOSEnvironment.TEST
+            }
 
             // Configura autenticação do comerciante
             val merchantAuth = WDePOSMerchantAuthentication()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,6 +50,7 @@ class _MyAppState extends State<MyApp> {
         expirationMonth: '12',
         expirationYear: '2030',
         cardCode: '123',
+        environment: 'test',
       );
       if (!mounted) return;
       setState(() {

--- a/ios/Classes/AuthorizeNetSdkPlugin.swift
+++ b/ios/Classes/AuthorizeNetSdkPlugin.swift
@@ -22,8 +22,10 @@ public class AuthorizeNetSdkPlugin: NSObject, FlutterPlugin {
         return
       }
 
+      let environmentArg = (args["environment"] as? String ?? "test").lowercased()
+
       // Configuração do ambiente (teste ou produção)
-      let environment: WDEPOSEnvironment = .test
+      let environment: WDEPOSEnvironment = environmentArg == "production" ? .production : .test
       
       // Configuração da autenticação do comerciante
       let merchantAuthentication = WDEPOSMerchantAuthentication()

--- a/lib/authorize_net_sdk_plugin.dart
+++ b/lib/authorize_net_sdk_plugin.dart
@@ -9,6 +9,7 @@ class AuthorizeNetSdkPlugin {
     required String expirationMonth,
     required String expirationYear,
     required String cardCode,
+    String environment = 'test',
   }) {
     return AuthorizeNetSdkPluginPlatform.instance.generateNonce(
       apiLoginId: apiLoginId,
@@ -17,6 +18,7 @@ class AuthorizeNetSdkPlugin {
       expirationMonth: expirationMonth,
       expirationYear: expirationYear,
       cardCode: cardCode,
+      environment: environment,
     );
   }
 

--- a/lib/authorize_net_sdk_plugin_method_channel.dart
+++ b/lib/authorize_net_sdk_plugin_method_channel.dart
@@ -23,6 +23,7 @@ class AuthorizeNetSdkPluginMethodChannel extends AuthorizeNetSdkPluginPlatform {
     required String expirationMonth,
     required String expirationYear,
     required String cardCode,
+    String environment = 'test',
   }) async {
     final args = {
       'apiLoginId': apiLoginId,
@@ -31,6 +32,7 @@ class AuthorizeNetSdkPluginMethodChannel extends AuthorizeNetSdkPluginPlatform {
       'expirationMonth': expirationMonth,
       'expirationYear': expirationYear,
       'cardCode': cardCode,
+      'environment': environment,
     };
 
     final nonce = await _channel.invokeMethod<String>('generateNonce', args);

--- a/lib/authorize_net_sdk_plugin_platform_interface.dart
+++ b/lib/authorize_net_sdk_plugin_platform_interface.dart
@@ -27,6 +27,7 @@ abstract class AuthorizeNetSdkPluginPlatform extends PlatformInterface {
     required String expirationMonth,
     required String expirationYear,
     required String cardCode,
+    String environment = 'test',
   }) {
     throw UnimplementedError('generateNonce() has not been implemented.');
   }

--- a/test/authorize_net_sdk_plugin_test.dart
+++ b/test/authorize_net_sdk_plugin_test.dart
@@ -17,6 +17,7 @@ class MockAuthorizeNetSdkPluginPlatform
     required String expirationMonth,
     required String expirationYear,
     required String cardCode,
+    String environment = 'test',
   }) async => 'mocked_nonce_123';
 }
 


### PR DESCRIPTION
## Summary
- allow choosing test or production on Android and iOS via new `environment` argument
- expose optional `environment` param in Dart API and example
- document environment usage

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_689c9ad09a8c8331bc6593747af127ac