### PR TITLE
feat: add web support with Accept.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,29 @@ pod 'WDePOS/All'
 
    ```dart
    final nonce = await authNet.generateNonce(
-     apiLoginId: 'YOUR_API_LOGIN_ID',
-     clientKey: 'YOUR_CLIENT_KEY',
-     cardNumber: '4111111111111111',
-     expirationMonth: '12',
-     expirationYear: '25',
-     cardCode: '123',
-   );
+      apiLoginId: 'YOUR_API_LOGIN_ID',
+      clientKey: 'YOUR_CLIENT_KEY',
+      cardNumber: '4111111111111111',
+      expirationMonth: '12',
+      expirationYear: '25',
+      cardCode: '123',
+    );
 
-   print('Generated nonce: $nonce');
+    print('Generated nonce: $nonce');
 
-   // Send this nonce securely to your backend to complete the payment
-   ```
+    // Send this nonce securely to your backend to complete the payment
+    ```
+
+### Web Support
+
+For Flutter Web you must load Authorize.Net's Accept.js library. Add the
+following script tag to your application's `web/index.html`:
+
+```html
+<script src="packages/authorize_net_sdk_plugin/authorize_net_sdk_plugin.js" defer></script>
+```
+
+This helper script injects the official Accept.js script so that
+`generateNonce` works in the browser.
+
+Use the plugin in your Dart code exactly as shown above.

--- a/lib/authorize_net_sdk_plugin.dart
+++ b/lib/authorize_net_sdk_plugin.dart
@@ -1,4 +1,6 @@
 import 'authorize_net_sdk_plugin_platform_interface.dart';
+export 'authorize_net_sdk_plugin_web_stub.dart'
+    if (dart.library.html) 'authorize_net_sdk_plugin_web.dart';
 
 class AuthorizeNetSdkPlugin {
   /// Gera o nonce/token para pagamento, chamando a implementação nativa via platform interface.

--- a/lib/authorize_net_sdk_plugin_web.dart
+++ b/lib/authorize_net_sdk_plugin_web.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'dart:js' as js;
+
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+import 'authorize_net_sdk_plugin_platform_interface.dart';
+
+/// Web implementation of [AuthorizeNetSdkPlugin] that uses Accept.js
+/// to tokenize payment information and generate a nonce.
+class AuthorizeNetSdkPluginWeb extends AuthorizeNetSdkPluginPlatform {
+  /// Registers this class as the default instance of
+  /// [AuthorizeNetSdkPluginPlatform] for web.
+  static void registerWith(Registrar registrar) {
+    AuthorizeNetSdkPluginPlatform.instance = AuthorizeNetSdkPluginWeb();
+  }
+
+  @override
+  Future<String?> getPlatformVersion() async => 'web';
+
+  @override
+  Future<String?> generateNonce({
+    required String apiLoginId,
+    required String clientKey,
+    required String cardNumber,
+    required String expirationMonth,
+    required String expirationYear,
+    required String cardCode,
+  }) {
+    final completer = Completer<String?>();
+
+    final authData = js.JsObject.jsify({
+      'clientKey': clientKey,
+      'apiLoginID': apiLoginId,
+    });
+
+    final cardData = js.JsObject.jsify({
+      'cardNumber': cardNumber,
+      'month': expirationMonth,
+      'year': expirationYear,
+      'cardCode': cardCode,
+    });
+
+    final secureData = js.JsObject.jsify({
+      'authData': authData,
+      'cardData': cardData,
+    });
+
+    js.context.callMethod('Accept.dispatchData', [
+      secureData,
+      js.allowInterop((response) {
+        final resultCode = response['messages']['resultCode'] as String?;
+        if (resultCode == 'Ok') {
+          final dataValue = response['opaqueData']['dataValue'] as String?;
+          completer.complete(dataValue);
+        } else {
+          final message = (response['messages']['message'] as List).first;
+          completer.completeError(message['text'] ?? 'Accept.js error');
+        }
+      }),
+    ]);
+
+    return completer.future;
+  }
+}

--- a/lib/authorize_net_sdk_plugin_web_stub.dart
+++ b/lib/authorize_net_sdk_plugin_web_stub.dart
@@ -1,0 +1,2 @@
+/// Stub implementation for non-web platforms.
+class AuthorizeNetSdkPluginWeb {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
+  flutter_web_plugins:
+    sdk: flutter
 
 dev_dependencies:
   flutter_test:
@@ -27,3 +29,6 @@ flutter:
         pluginClass: AuthorizeNetSdkPlugin
       ios:
         pluginClass: AuthorizeNetSdkPlugin
+      web:
+        pluginClass: AuthorizeNetSdkPluginWeb
+        fileName: authorize_net_sdk_plugin_web.dart

--- a/web/authorize_net_sdk_plugin.js
+++ b/web/authorize_net_sdk_plugin.js
@@ -1,0 +1,5 @@
+(function() {
+  var script = document.createElement('script');
+  script.src = 'https://js.authorize.net/v1/Accept.js';
+  document.head.appendChild(script);
+})();


### PR DESCRIPTION
## Summary
- add `AuthorizeNetSdkPluginWeb` that uses Accept.js to generate nonces
- wire web platform into plugin registration and provide Accept.js loader
- document browser usage and update pubspec for web support

## Testing
- `dart format lib/authorize_net_sdk_plugin_web_stub.dart lib/authorize_net_sdk_plugin_web.dart lib/authorize_net_sdk_plugin.dart`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_b_689c9d8724dc83318de2df461c6803ae