### PR TITLE
Add getPlatformVersion handlers for Android and iOS

### DIFF
--- a/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
+++ b/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
@@ -67,6 +67,8 @@ public class AuthorizeNetSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHand
                 }
             })
 
+        } else if (call.method == "getPlatformVersion") {
+            result.success(android.os.Build.VERSION.RELEASE)
         } else {
             result.notImplemented()
         }

--- a/ios/Classes/AuthorizeNetSdkPlugin.swift
+++ b/ios/Classes/AuthorizeNetSdkPlugin.swift
@@ -50,6 +50,8 @@ public class AuthorizeNetSdkPlugin: NSObject, FlutterPlugin {
           result(FlutterError(code: "UNKNOWN", message: "Erro desconhecido", details: nil))
         }
       }
+    } else if call.method == "getPlatformVersion" {
+      result(UIDevice.current.systemVersion)
     } else {
       result(FlutterMethodNotImplemented)
     }


### PR DESCRIPTION
## Summary
- Handle `getPlatformVersion` in Android plugin by returning `android.os.Build.VERSION.RELEASE`
- Handle `getPlatformVersion` in iOS plugin by returning `UIDevice.current.systemVersion`
- Confirm method channel still invokes `getPlatformVersion`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ca1d6d6d88331b3370d8d0497a1aa