### PR TITLE
feat: add Accept.js readiness check

### DIFF
--- a/lib/authorize_net_sdk_plugin.dart
+++ b/lib/authorize_net_sdk_plugin.dart
@@ -3,6 +3,11 @@ export 'authorize_net_sdk_plugin_web_stub.dart'
     if (dart.library.html) 'authorize_net_sdk_plugin_web.dart';
 
 class AuthorizeNetSdkPlugin {
+  /// Checks if the underlying implementation is ready to generate a nonce.
+  Future<bool> isReady() {
+    return AuthorizeNetSdkPluginPlatform.instance.isReady();
+  }
+
   /// Gera o nonce/token para pagamento, chamando a implementação nativa via platform interface.
   Future<String?> generateNonce({
     required String apiLoginId,

--- a/lib/authorize_net_sdk_plugin_method_channel.dart
+++ b/lib/authorize_net_sdk_plugin_method_channel.dart
@@ -14,6 +14,9 @@ class AuthorizeNetSdkPluginMethodChannel extends AuthorizeNetSdkPluginPlatform {
     return version;
   }
 
+  @override
+  Future<bool> isReady() async => true;
+
   // Método que chama o código nativo para gerar o nonce de pagamento
   @override
   Future<String?> generateNonce({

--- a/lib/authorize_net_sdk_plugin_platform_interface.dart
+++ b/lib/authorize_net_sdk_plugin_platform_interface.dart
@@ -20,6 +20,10 @@ abstract class AuthorizeNetSdkPluginPlatform extends PlatformInterface {
     throw UnimplementedError('getPlatformVersion() has not been implemented.');
   }
 
+  Future<bool> isReady() {
+    throw UnimplementedError('isReady() has not been implemented.');
+  }
+
   Future<String?> generateNonce({
     required String apiLoginId,
     required String clientKey,

--- a/lib/authorize_net_sdk_plugin_web.dart
+++ b/lib/authorize_net_sdk_plugin_web.dart
@@ -18,6 +18,9 @@ class AuthorizeNetSdkPluginWeb extends AuthorizeNetSdkPluginPlatform {
   Future<String?> getPlatformVersion() async => 'web';
 
   @override
+  Future<bool> isReady() async => js.context['Accept'] != null;
+
+  @override
   Future<String?> generateNonce({
     required String apiLoginId,
     required String clientKey,
@@ -27,6 +30,11 @@ class AuthorizeNetSdkPluginWeb extends AuthorizeNetSdkPluginPlatform {
     required String cardCode,
   }) {
     final completer = Completer<String?>();
+
+    if (js.context['Accept'] == null) {
+      completer.completeError('Accept.js is not loaded');
+      return completer.future;
+    }
 
     final authData = js.JsObject.jsify({
       'clientKey': clientKey,

--- a/test/authorize_net_sdk_plugin_method_channel_test.dart
+++ b/test/authorize_net_sdk_plugin_method_channel_test.dart
@@ -16,6 +16,11 @@ void main() {
     channel.setMockMethodCallHandler(null);
   });
 
+  test('isReady returns true', () async {
+    final ready = await plugin.isReady();
+    expect(ready, true);
+  });
+
   test('getPlatformVersion returns correct version', () async {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       if (methodCall.method == 'getPlatformVersion') {

--- a/test/authorize_net_sdk_plugin_test.dart
+++ b/test/authorize_net_sdk_plugin_test.dart
@@ -10,6 +10,9 @@ class MockAuthorizeNetSdkPluginPlatform
   Future<String?> getPlatformVersion() async => '42';
 
   @override
+  Future<bool> isReady() async => true;
+
+  @override
   Future<String?> generateNonce({
     required String apiLoginId,
     required String clientKey,
@@ -28,6 +31,11 @@ void main() {
     plugin = AuthorizeNetSdkPlugin();
     mockPlatform = MockAuthorizeNetSdkPluginPlatform();
     AuthorizeNetSdkPluginPlatform.instance = mockPlatform;
+  });
+
+  test('isReady returns true', () async {
+    final ready = await plugin.isReady();
+    expect(ready, true);
   });
 
   test('getPlatformVersion returns mocked version', () async {


### PR DESCRIPTION
## Summary
- ensure Accept.js is loaded before dispatching data on web
- expose `isReady` API for readiness checks across platforms
- cover new readiness API in unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ca1e3cf048331aacc73c03253a5a2