### PR TITLE
Add environment parameter to generateNonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ pod 'WDePOS/All'
 
 3. Generate a payment nonce:
 
+   Pass the `environment` parameter as `'test'` or `'production'` to select the Authorize.Net environment.
+
    ```dart
+   // Using the test environment
    final nonce = await authNet.generateNonce(
       apiLoginId: 'YOUR_API_LOGIN_ID',
       clientKey: 'YOUR_CLIENT_KEY',
@@ -65,12 +68,27 @@ pod 'WDePOS/All'
       expirationMonth: '12',
       expirationYear: '25',
       cardCode: '123',
+      environment: 'test', // or 'production'
     );
 
     print('Generated nonce: $nonce');
 
     // Send this nonce securely to your backend to complete the payment
     ```
+
+   To use the production environment, set `environment: 'production'`:
+
+   ```dart
+   final prodNonce = await authNet.generateNonce(
+      apiLoginId: 'YOUR_API_LOGIN_ID',
+      clientKey: 'YOUR_CLIENT_KEY',
+      cardNumber: '4111111111111111',
+      expirationMonth: '12',
+      expirationYear: '25',
+      cardCode: '123',
+      environment: 'production',
+    );
+   ```
 
 ### Web Support
 

--- a/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
+++ b/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
@@ -32,6 +32,7 @@ public class AuthorizeNetSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHand
             val expirationMonth = call.argument<String>("expirationMonth") ?: ""
             val expirationYear = call.argument<String>("expirationYear") ?: ""
             val cardCode = call.argument<String>("cardCode") ?: ""
+            val environmentArg = call.argument<String>("environment") ?: "test"
 
             if (apiLoginId.isEmpty() || clientKey.isEmpty() || cardNumber.isEmpty() || expirationMonth.isEmpty() || expirationYear.isEmpty() || cardCode.isEmpty()) {
                 result.error("INVALID_ARGS", "Parâmetros inválidos ou faltando", null)
@@ -39,7 +40,11 @@ public class AuthorizeNetSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHand
             }
 
             // Configura o ambiente (sandbox/teste ou produção)
-            val environment = WDePOSEnvironment.TEST
+            val environment = if (environmentArg == "production") {
+                WDePOSEnvironment.PRODUCTION
+            } else {
+                WDePOSEnvironment.TEST
+            }
 
             // Configura autenticação do comerciante
             val merchantAuth = WDePOSMerchantAuthentication()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,6 +50,7 @@ class _MyAppState extends State<MyApp> {
         expirationMonth: '12',
         expirationYear: '2030',
         cardCode: '123',
+        environment: 'test',
       );
       if (!mounted) return;
       setState(() {

--- a/ios/Classes/AuthorizeNetSdkPlugin.swift
+++ b/ios/Classes/AuthorizeNetSdkPlugin.swift
@@ -22,8 +22,10 @@ public class AuthorizeNetSdkPlugin: NSObject, FlutterPlugin {
         return
       }
 
+      let environmentArg = args["environment"] as? String ?? "test"
+
       // Configuração do ambiente (teste ou produção)
-      let environment: WDEPOSEnvironment = .test
+      let environment: WDEPOSEnvironment = (environmentArg == "production") ? .production : .test
       
       // Configuração da autenticação do comerciante
       let merchantAuthentication = WDEPOSMerchantAuthentication()

--- a/lib/authorize_net_sdk_plugin.dart
+++ b/lib/authorize_net_sdk_plugin.dart
@@ -11,6 +11,7 @@ class AuthorizeNetSdkPlugin {
     required String expirationMonth,
     required String expirationYear,
     required String cardCode,
+    String environment = 'test',
   }) {
     return AuthorizeNetSdkPluginPlatform.instance.generateNonce(
       apiLoginId: apiLoginId,
@@ -19,6 +20,7 @@ class AuthorizeNetSdkPlugin {
       expirationMonth: expirationMonth,
       expirationYear: expirationYear,
       cardCode: cardCode,
+      environment: environment,
     );
   }
 

--- a/lib/authorize_net_sdk_plugin_method_channel.dart
+++ b/lib/authorize_net_sdk_plugin_method_channel.dart
@@ -23,6 +23,7 @@ class AuthorizeNetSdkPluginMethodChannel extends AuthorizeNetSdkPluginPlatform {
     required String expirationMonth,
     required String expirationYear,
     required String cardCode,
+    String environment = 'test',
   }) async {
     final args = {
       'apiLoginId': apiLoginId,
@@ -31,6 +32,7 @@ class AuthorizeNetSdkPluginMethodChannel extends AuthorizeNetSdkPluginPlatform {
       'expirationMonth': expirationMonth,
       'expirationYear': expirationYear,
       'cardCode': cardCode,
+      'environment': environment,
     };
 
     final nonce = await _channel.invokeMethod<String>('generateNonce', args);

--- a/lib/authorize_net_sdk_plugin_platform_interface.dart
+++ b/lib/authorize_net_sdk_plugin_platform_interface.dart
@@ -27,6 +27,7 @@ abstract class AuthorizeNetSdkPluginPlatform extends PlatformInterface {
     required String expirationMonth,
     required String expirationYear,
     required String cardCode,
+    String environment = 'test',
   }) {
     throw UnimplementedError('generateNonce() has not been implemented.');
   }

--- a/lib/authorize_net_sdk_plugin_web.dart
+++ b/lib/authorize_net_sdk_plugin_web.dart
@@ -25,6 +25,7 @@ class AuthorizeNetSdkPluginWeb extends AuthorizeNetSdkPluginPlatform {
     required String expirationMonth,
     required String expirationYear,
     required String cardCode,
+    String environment = 'test',
   }) {
     final completer = Completer<String?>();
 

--- a/test/authorize_net_sdk_plugin_method_channel_test.dart
+++ b/test/authorize_net_sdk_plugin_method_channel_test.dart
@@ -33,7 +33,8 @@ void main() {
 
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       if (methodCall.method == 'generateNonce') {
-        // Você pode checar args aqui se quiser
+        final args = methodCall.arguments as Map;
+        expect(args['environment'], 'test');
         return fakeNonce;
       }
       return null;
@@ -46,6 +47,7 @@ void main() {
       expirationMonth: '12',
       expirationYear: '25',
       cardCode: '123',
+      environment: 'test',
     );
 
     expect(nonce, fakeNonce);

--- a/test/authorize_net_sdk_plugin_test.dart
+++ b/test/authorize_net_sdk_plugin_test.dart
@@ -17,6 +17,7 @@ class MockAuthorizeNetSdkPluginPlatform
     required String expirationMonth,
     required String expirationYear,
     required String cardCode,
+    String environment = 'test',
   }) async => 'mocked_nonce_123';
 }
 
@@ -43,6 +44,7 @@ void main() {
       expirationMonth: '12',
       expirationYear: '25',
       cardCode: '123',
+      environment: 'test',
     );
     expect(nonce, 'mocked_nonce_123');
   });


### PR DESCRIPTION
## Summary
- allow specifying test or production environment when generating nonces
- wire environment through Android and iOS implementations
- document environment usage in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ca1dda98083318ae6f64471d51016