### PR TITLE
docs: add changelog entry for 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.0.5] - 2025-08-13
+### Added
+- Environment parameter for `generateNonce` and platform version getters for Android and iOS.
+- Accept.js readiness check.
+### Changed
+- Bumped plugin version and updated dependencies.
+- Refreshed WDePOS SDK support.
+### Fixed
+- Ensured Accept.js context is validated before dispatching data.
+
 ## [0.0.4] - 2025-08-12
 ### Added
 - Support for WDePOS on iOS and Android.


### PR DESCRIPTION
## Summary
- document 0.0.5 release: environment parameter for `generateNonce`, Accept.js readiness check, dependency refresh, and updated WDePOS support.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ca575fad8833192d8a9a9162328f4