### PR TITLE
chore: update podspec maintainer email

### DIFF
--- a/ios/authorize_net_sdk_plugin.podspec
+++ b/ios/authorize_net_sdk_plugin.podspec
@@ -11,7 +11,7 @@ Plugin Flutter para integrar com o Authorize.net usando o WDePOS SDK no iOS.
   DESC
   s.homepage         = 'https://github.com/lucascelopes/Authorize_net_sdk_plugin'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Nagazaki Software' => 'email@example.com' }
+  s.author           = { 'Nagazaki Software' => 'lucascesarlopes@nagazakisofware.com.br' }
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.platform         = :ios, '12.0'


### PR DESCRIPTION
## Summary
- set valid maintainer email in iOS podspec
- verify podspec metadata is configured for publication

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `pod lib lint ios/authorize_net_sdk_plugin.podspec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ca58fb3d08331a89c7e4d418236b3