### PR TITLE
feat: add native isReady checks

### DIFF
--- a/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
+++ b/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
@@ -25,7 +25,9 @@ public class AuthorizeNetSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHand
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        if (call.method == "generateNonce") {
+        if (call.method == "isReady") {
+            result.success(isSdkAvailable())
+        } else if (call.method == "generateNonce") {
             val apiLoginId = call.argument<String>("apiLoginId") ?: ""
             val clientKey = call.argument<String>("clientKey") ?: ""
             val cardNumber = call.argument<String>("cardNumber") ?: ""
@@ -81,5 +83,14 @@ public class AuthorizeNetSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHand
 
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+    }
+
+    private fun isSdkAvailable(): Boolean {
+        return try {
+            Class.forName("com.wdepos.sdk.WDePOSService")
+            true
+        } catch (e: Exception) {
+            false
+        }
     }
 }

--- a/ios/Classes/AuthorizeNetSdkPlugin.swift
+++ b/ios/Classes/AuthorizeNetSdkPlugin.swift
@@ -52,6 +52,9 @@ public class AuthorizeNetSdkPlugin: NSObject, FlutterPlugin {
           result(FlutterError(code: "UNKNOWN", message: "Erro desconhecido", details: nil))
         }
       }
+    } else if call.method == "isReady" {
+      let ready = (NSClassFromString("WDEPOSService") != nil)
+      result(ready)
     } else if call.method == "getPlatformVersion" {
       result(UIDevice.current.systemVersion)
     } else {

--- a/lib/authorize_net_sdk_plugin_method_channel.dart
+++ b/lib/authorize_net_sdk_plugin_method_channel.dart
@@ -15,7 +15,14 @@ class AuthorizeNetSdkPluginMethodChannel extends AuthorizeNetSdkPluginPlatform {
   }
 
   @override
-  Future<bool> isReady() async => true;
+  Future<bool> isReady() async {
+    try {
+      final ready = await _channel.invokeMethod<bool>('isReady');
+      return ready ?? false;
+    } on PlatformException {
+      return false;
+    }
+  }
 
   // Método que chama o código nativo para gerar o nonce de pagamento
   @override

--- a/test/authorize_net_sdk_plugin_method_channel_test.dart
+++ b/test/authorize_net_sdk_plugin_method_channel_test.dart
@@ -16,9 +16,28 @@ void main() {
     channel.setMockMethodCallHandler(null);
   });
 
-  test('isReady returns true', () async {
+  test('isReady returns true when native reports ready', () async {
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'isReady') {
+        return true;
+      }
+      return null;
+    });
+
     final ready = await plugin.isReady();
     expect(ready, true);
+  });
+
+  test('isReady returns false on platform error', () async {
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'isReady') {
+        throw PlatformException(code: 'UNAVAILABLE');
+      }
+      return null;
+    });
+
+    final ready = await plugin.isReady();
+    expect(ready, false);
   });
 
   test('getPlatformVersion returns correct version', () async {

--- a/test/authorize_net_sdk_plugin_test.dart
+++ b/test/authorize_net_sdk_plugin_test.dart
@@ -6,11 +6,12 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 class MockAuthorizeNetSdkPluginPlatform
     with MockPlatformInterfaceMixin
     implements AuthorizeNetSdkPluginPlatform {
+  bool ready = true;
   @override
   Future<String?> getPlatformVersion() async => '42';
 
   @override
-  Future<bool> isReady() async => true;
+  Future<bool> isReady() async => ready;
 
   @override
   Future<String?> generateNonce({
@@ -37,6 +38,12 @@ void main() {
   test('isReady returns true', () async {
     final ready = await plugin.isReady();
     expect(ready, true);
+  });
+
+  test('isReady returns false', () async {
+    mockPlatform.ready = false;
+    final ready = await plugin.isReady();
+    expect(ready, false);
   });
 
   test('getPlatformVersion returns mocked version', () async {


### PR DESCRIPTION
## Summary
- add isReady handler for Android and iOS SDK availability
- invoke isReady through method channel and handle errors
- cover ready/failed scenarios in tests

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_b_689ca58804308331beb994268f46ee18