### PR TITLE
Handle PlatformException in generateNonce

### DIFF
--- a/lib/authorize_net_sdk_plugin_method_channel.dart
+++ b/lib/authorize_net_sdk_plugin_method_channel.dart
@@ -45,7 +45,12 @@ class AuthorizeNetSdkPluginMethodChannel extends AuthorizeNetSdkPluginPlatform {
       'environment': environment,
     };
 
-    final nonce = await _channel.invokeMethod<String>('generateNonce', args);
-    return nonce;
+    try {
+      final nonce =
+          await _channel.invokeMethod<String>('generateNonce', args);
+      return nonce;
+    } on PlatformException catch (e) {
+      throw Exception('Erro (${e.code}): ${e.message}');
+    }
   }
 }


### PR DESCRIPTION
## Summary
- handle PlatformException in generateNonce and rethrow a user friendly error

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ca86261308331af07f65dcb0e70b8