### PR TITLE
Handle missing Accept.js error messages

### DIFF
--- a/lib/authorize_net_sdk_plugin_web.dart
+++ b/lib/authorize_net_sdk_plugin_web.dart
@@ -62,8 +62,16 @@ class AuthorizeNetSdkPluginWeb extends AuthorizeNetSdkPluginPlatform {
           final dataValue = response['opaqueData']['dataValue'] as String?;
           completer.complete(dataValue);
         } else {
-          final message = (response['messages']['message'] as List).first;
-          completer.completeError(message['text'] ?? 'Accept.js error');
+          final messages = response['messages'];
+          final messageList = messages is Map
+              ? messages['message'] as List?
+              : null;
+          if (messageList != null && messageList.isNotEmpty) {
+            final message = messageList.first;
+            completer.completeError(message['text'] ?? 'Accept.js error');
+          } else {
+            completer.completeError('Accept.js error');
+          }
         }
       }),
     ]);


### PR DESCRIPTION
## Summary
- Safely handle Accept.js error responses by checking for message list and defaulting to a generic error when absent

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_b_689ca86d69e48331af5a45aa065df68a