### PR TITLE
Ensure result callbacks run on main thread

### DIFF
--- a/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
+++ b/android/src/main/kotlin/com/example/authorize_net_sdk_plugin/AuthorizeNetSdkPlugin.kt
@@ -1,6 +1,8 @@
 package com.example.authorize_net_sdk_plugin
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.NonNull
 import com.wdepos.sdk.WDePOSService
 import com.wdepos.sdk.WDePOSServiceCallback
@@ -66,11 +68,15 @@ public class AuthorizeNetSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHand
             // Chama geração do token (nonce)
             wdeposService.generateToken(card, object : WDePOSServiceCallback {
                 override fun onSuccess(token: String) {
-                    result.success(token)
+                    Handler(Looper.getMainLooper()).post {
+                        result.success(token)
+                    }
                 }
 
                 override fun onFailure(errorMessage: String) {
-                    result.error("ERROR", errorMessage, null)
+                    Handler(Looper.getMainLooper()).post {
+                        result.error("ERROR", errorMessage, null)
+                    }
                 }
             })
 


### PR DESCRIPTION
## Summary
- Wrap token generation callbacks with `Handler` posting to the main Looper
- Import `Handler` and `Looper` for main-thread execution

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_b_689ca8784f9483319c680e11b302558b