### PR TITLE
test: cover edge cases in nonce generation

### DIFF
--- a/test/authorize_net_sdk_plugin_method_channel_test.dart
+++ b/test/authorize_net_sdk_plugin_method_channel_test.dart
@@ -76,4 +76,54 @@ void main() {
 
     expect(nonce, fakeNonce);
   });
+
+  test('generateNonce throws PlatformException on missing parameter', () {
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'generateNonce') {
+        final args = methodCall.arguments as Map;
+        if ((args['cardCode'] as String).isEmpty) {
+          throw PlatformException(code: 'INVALID_ARGS');
+        }
+      }
+      return null;
+    });
+
+    expect(
+      () => plugin.generateNonce(
+        apiLoginId: 'apiLoginId',
+        clientKey: 'clientKey',
+        cardNumber: '4111111111111111',
+        expirationMonth: '12',
+        expirationYear: '25',
+        cardCode: '',
+        environment: 'test',
+      ),
+      throwsA(isA<PlatformException>()),
+    );
+  });
+
+  test('generateNonce throws when isReady reports false', () {
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      if (methodCall.method == 'isReady') {
+        return false;
+      }
+      if (methodCall.method == 'generateNonce') {
+        throw PlatformException(code: 'NOT_READY');
+      }
+      return null;
+    });
+
+    expect(
+      () => plugin.generateNonce(
+        apiLoginId: 'apiLoginId',
+        clientKey: 'clientKey',
+        cardNumber: '4111111111111111',
+        expirationMonth: '12',
+        expirationYear: '25',
+        cardCode: '123',
+        environment: 'test',
+      ),
+      throwsA(isA<PlatformException>()),
+    );
+  });
 }

--- a/test/authorize_net_sdk_plugin_test.dart
+++ b/test/authorize_net_sdk_plugin_test.dart
@@ -22,7 +22,23 @@ class MockAuthorizeNetSdkPluginPlatform
     required String expirationYear,
     required String cardCode,
     String environment = 'test',
-  }) async => 'mocked_nonce_123';
+  }) async {
+    if (!ready) {
+      throw StateError('Plugin not ready');
+    }
+    final params = [
+      apiLoginId,
+      clientKey,
+      cardNumber,
+      expirationMonth,
+      expirationYear,
+      cardCode,
+    ];
+    if (params.any((p) => p.isEmpty)) {
+      throw ArgumentError('Missing parameter');
+    }
+    return 'mocked_nonce_123';
+  }
 }
 
 void main() {
@@ -62,5 +78,36 @@ void main() {
       environment: 'test',
     );
     expect(nonce, 'mocked_nonce_123');
+  });
+
+  test('generateNonce throws when plugin not ready', () {
+    mockPlatform.ready = false;
+    expect(
+      () => plugin.generateNonce(
+        apiLoginId: 'dummyApiLoginId',
+        clientKey: 'dummyClientKey',
+        cardNumber: '4111111111111111',
+        expirationMonth: '12',
+        expirationYear: '25',
+        cardCode: '123',
+        environment: 'test',
+      ),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('generateNonce throws when required parameter is empty', () {
+    expect(
+      () => plugin.generateNonce(
+        apiLoginId: '',
+        clientKey: 'dummyClientKey',
+        cardNumber: '4111111111111111',
+        expirationMonth: '12',
+        expirationYear: '25',
+        cardCode: '123',
+        environment: 'test',
+      ),
+      throwsA(isA<ArgumentError>()),
+    );
   });
 }

--- a/test/authorize_net_sdk_plugin_web_test.dart
+++ b/test/authorize_net_sdk_plugin_web_test.dart
@@ -1,0 +1,59 @@
+@TestOn('browser')
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:js' as js;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:authorize_net_sdk_plugin/authorize_net_sdk_plugin_web.dart';
+
+void main() {
+  group('AuthorizeNetSdkPluginWeb', () {
+    late AuthorizeNetSdkPluginWeb plugin;
+
+    setUp(() {
+      plugin = AuthorizeNetSdkPluginWeb();
+      js.context['Accept'] = null;
+    });
+
+    test('isReady returns false when Accept is missing', () async {
+      final ready = await plugin.isReady();
+      expect(ready, false);
+    });
+
+    test('generateNonce throws when Accept is missing', () async {
+      await expectLater(
+        plugin.generateNonce(
+          apiLoginId: 'apiLoginId',
+          clientKey: 'clientKey',
+          cardNumber: '4111111111111111',
+          expirationMonth: '12',
+          expirationYear: '25',
+          cardCode: '123',
+        ),
+        throwsA(isA<String>()),
+      );
+    });
+
+    test('generateNonce throws when response has no messages', () async {
+      js.context['Accept'] = js.JsObject.jsify({
+        'dispatchData': js.allowInterop((secureData, callback) {
+          callback(
+            js.JsObject.jsify({
+              'opaqueData': js.JsObject.jsify({'dataValue': 'nonce'}),
+            }),
+          );
+        }),
+      });
+
+      await expectLater(
+        plugin.generateNonce(
+          apiLoginId: 'apiLoginId',
+          clientKey: 'clientKey',
+          cardNumber: '4111111111111111',
+          expirationMonth: '12',
+          expirationYear: '25',
+          cardCode: '123',
+        ),
+        throwsA(isA<Error>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- validate readiness and required parameters in mock platform
- test method channel errors for missing params and not-ready state
- add browser tests for missing Accept.js or malformed responses

## Testing
- `flutter test`
- `flutter test --platform=chrome test/authorize_net_sdk_plugin_web_test.dart` *(fails: Failed to find "google-chrome" in the search path)*

------
https://chatgpt.com/codex/tasks/task_b_689ca87bc9248331ad55efedf3bfa678