### PR TITLE
Validate required fields before Accept.js dispatch on web

### DIFF
--- a/lib/authorize_net_sdk_plugin_web.dart
+++ b/lib/authorize_net_sdk_plugin_web.dart
@@ -37,6 +37,16 @@ class AuthorizeNetSdkPluginWeb extends AuthorizeNetSdkPluginPlatform {
       return completer.future;
     }
 
+    if (apiLoginId.isEmpty ||
+        clientKey.isEmpty ||
+        cardNumber.isEmpty ||
+        expirationMonth.isEmpty ||
+        expirationYear.isEmpty ||
+        cardCode.isEmpty) {
+      completer.completeError('Parâmetros inválidos ou faltando');
+      return completer.future;
+    }
+
     final authData = js.JsObject.jsify({
       'clientKey': clientKey,
       'apiLoginID': apiLoginId,

--- a/test/authorize_net_sdk_plugin_web_test.dart
+++ b/test/authorize_net_sdk_plugin_web_test.dart
@@ -32,6 +32,22 @@ void main() {
       );
     });
 
+    test('generateNonce throws when any field is empty', () async {
+      js.context['Accept'] = js.JsObject.jsify({});
+
+      await expectLater(
+        plugin.generateNonce(
+          apiLoginId: '',
+          clientKey: 'clientKey',
+          cardNumber: '4111111111111111',
+          expirationMonth: '12',
+          expirationYear: '25',
+          cardCode: '123',
+        ),
+        throwsA('Parâmetros inválidos ou faltando'),
+      );
+    });
+
     test('generateNonce throws when response has no messages', () async {
       js.context['Accept'] = js.JsObject.jsify({
         'dispatchData': js.allowInterop((secureData, callback) {


### PR DESCRIPTION
## Summary
- ensure web implementation errors when any required field is empty before calling Accept.js
- add web test covering empty field scenario

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cac9f96148331bba913172d2c8344